### PR TITLE
Disable CI on macOS

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,6 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^\.lintr$
+^\.renovaterc\.json5$
+^\.vscode$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,30 +48,12 @@ jobs:
                   http-user-agent: ${{ matrix.config.http-user-agent }}
                   use-public-rspm: true
 
-            # Install miniconda manually, to prevent installation errors on GHA runners
-            - name: Setup Miniconda
-              uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
-
-            - name: Install basilisk
-              if: runner.os == 'macOS'
-              # avoids conda installation error on macOS
-              run: |
-                  Rscript -e 'install.packages("BiocManager")'
-                  unset DYLD_FALLBACK_LIBRARY_PATH  && \
-                    Rscript -e 'BiocManager::install("basilisk", type="source")'
-
             - name: Install R dependencies
               uses: r-lib/actions/setup-r-dependencies@929c772977a3a13c8733b363bf5a2f685c25dd91 # v2
               with:
                   cache-version: 3
                   extra-packages: any::rcmdcheck
                   needs: check
-
-            - name: Check basilisk conda installation
-              shell: Rscript {0}
-              run: |
-                  basilisk.utils::getCondaDir()
-                  basilisk::configureBasiliskEnv()
 
             - name: Run R CMD check
               uses: r-lib/actions/check-r-package@929c772977a3a13c8733b363bf5a2f685c25dd91 # v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -61,16 +61,17 @@ jobs:
 
             - name: Install basilisk
               if: runner.os == 'macOS'
+              # avoids conda installation error on macOS
               run: |
                   Rscript -e 'install.packages("BiocManager")'
-                  unset DYLD_FALLBACK_LIBRARY_PATH  && \ # avoids conda installation error on macOS
+                  unset DYLD_FALLBACK_LIBRARY_PATH  && \
                     Rscript -e 'BiocManager::install("basilisk", type="source")'
 
-            # Install conda for basilisk manually
             - name: Check basilisk conda installation
               shell: Rscript {0}
               run: |
                   basilisk.utils::getCondaDir()
+                  basilisk::configureBasiliskEnv()
 
             - name: Run R CMD check
               uses: r-lib/actions/check-r-package@929c772977a3a13c8733b363bf5a2f685c25dd91 # v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,7 +20,6 @@ jobs:
             matrix:
                 config:
                     - { os: macos-latest, r: "release" }
-                    - { os: macos-13, r: "release" }
                     - { os: windows-latest, r: "release" }
                     - { os: ubuntu-latest, r: "devel", http-user-agent: "release" }
                     - { os: ubuntu-latest, r: "release" }
@@ -54,7 +53,10 @@ jobs:
             # Install conda for basilisk manually
             - name: Setup basilisk conda
               shell: Rscript {0}
-              run: basilisk.utils::installConda()
+              run: |
+                  Sys.setenv(BASILISK_USE_SYSTEM_DIR=1)
+                  basilisk.utils::installConda()
+                  basilisk.utils::getCondaDir()
 
             - name: Install R dependencies
               uses: r-lib/actions/setup-r-dependencies@7171bbdc297d5a76f04914d60e5c8144991e3011 # v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,7 +56,7 @@ jobs:
                   needs: check
 
             - name: Install basilisk
-              if: runner.os == 'macOS
+              if: runner.os == 'macOS'
               run: |
                   Rscript -e 'install.packages("BiocManager")'
                   unset DYLD_FALLBACK_LIBRARY_PATH  && \ # avoids conda installation error on macOS

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,6 +47,7 @@ jobs:
               shell: Rscript {0}
               run: |
                   install.packages("BiocManager")
+                  BiocManager::install("basilisk")
                   BiocManager::install("basilisk.utils")
 
             # Install conda for basilisk manually

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,6 +20,7 @@ jobs:
             matrix:
                 config:
                     - { os: macos-latest, r: "release" }
+                    - { os: macos-13, r: "release" }
                     - { os: windows-latest, r: "release" }
                     - { os: ubuntu-latest, r: "devel", http-user-agent: "release" }
                     - { os: ubuntu-latest, r: "release" }
@@ -43,7 +44,7 @@ jobs:
                   http-user-agent: ${{ matrix.config.http-user-agent }}
                   use-public-rspm: true
 
-            - name: Install basilisk.utils
+            - name: Install basilisk
               shell: Rscript {0}
               run: |
                   install.packages("BiocManager")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,6 +33,7 @@ jobs:
         env:
             GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
             R_KEEP_PKG_SOURCE: yes
+            BASILISK_USE_SYSTEM_DIR: 1
 
         steps:
             - name: Checkout repo
@@ -56,11 +57,9 @@ jobs:
                   BiocManager::install("basilisk.utils")
 
             # Install conda for basilisk manually
-            - name: Setup basilisk conda
+            - name: Check basilisk conda installation
               shell: Rscript {0}
               run: |
-                  Sys.setenv(BASILISK_USE_SYSTEM_DIR=1)
-                  basilisk.utils::installConda()
                   basilisk.utils::getCondaDir()
 
             - name: Install R dependencies

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,11 @@ on:
 
 name: R-CMD-check
 
+# Only run actions on the most recent push to a branch
+concurrency:
+    group: "${{ github.workflow }}-${{ github.head_ref }}"
+    cancel-in-progress: true
+
 jobs:
     R-CMD-check:
         runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,8 +53,7 @@ jobs:
               shell: Rscript {0}
               run: |
                   install.packages("BiocManager")
-                  BiocManager::install("basilisk")
-                  BiocManager::install("basilisk.utils")
+                  BiocManager::install("basilisk", type="source")
 
             # Install conda for basilisk manually
             - name: Check basilisk conda installation

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,6 +56,7 @@ jobs:
                   needs: check
 
             - name: Install basilisk
+              if: runner.os == 'macOS
               run: |
                   Rscript -e 'install.packages("BiocManager")'
                   unset DYLD_FALLBACK_LIBRARY_PATH  && \ # avoids conda installation error on macOS

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,12 +52,6 @@ jobs:
             - name: Setup Miniconda
               uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
 
-            - name: Install R dependencies
-              uses: r-lib/actions/setup-r-dependencies@929c772977a3a13c8733b363bf5a2f685c25dd91 # v2
-              with:
-                  extra-packages: any::rcmdcheck
-                  needs: check
-
             - name: Install basilisk
               if: runner.os == 'macOS'
               # avoids conda installation error on macOS
@@ -65,6 +59,13 @@ jobs:
                   Rscript -e 'install.packages("BiocManager")'
                   unset DYLD_FALLBACK_LIBRARY_PATH  && \
                     Rscript -e 'BiocManager::install("basilisk", type="source")'
+
+            - name: Install R dependencies
+              uses: r-lib/actions/setup-r-dependencies@929c772977a3a13c8733b363bf5a2f685c25dd91 # v2
+              with:
+                  cache-version: 3
+                  extra-packages: any::rcmdcheck
+                  needs: check
 
             - name: Check basilisk conda installation
               shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,7 +24,9 @@ jobs:
             fail-fast: false
             matrix:
                 config:
-                    - { os: macos-latest, r: "release" }
+                    # TODO: fix broken macOS workflow
+                    # https://github.com/milanmlft/jupytextR/issues/28
+                    # - { os: macos-latest, r: "release" }
                     - { os: windows-latest, r: "release" }
                     - { os: ubuntu-latest, r: "devel", http-user-agent: "release" }
                     - { os: ubuntu-latest, r: "release" }

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,7 +33,6 @@ jobs:
         env:
             GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
             R_KEEP_PKG_SOURCE: yes
-            BASILISK_USE_SYSTEM_DIR: 1
 
         steps:
             - name: Checkout repo

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,23 +49,23 @@ jobs:
                   http-user-agent: ${{ matrix.config.http-user-agent }}
                   use-public-rspm: true
 
+            - name: Install R dependencies
+              uses: r-lib/actions/setup-r-dependencies@7171bbdc297d5a76f04914d60e5c8144991e3011 # v2
+              with:
+                  extra-packages: any::rcmdcheck
+                  needs: check
+
             - name: Install basilisk
               run: |
                   Rscript -e 'install.packages("BiocManager")'
-                  unset DYLD_FALLBACK_LIBRARY_PATH # avoids conda installation error on macOS
-                  Rscript -e 'BiocManager::install("basilisk", type="source")'
+                  unset DYLD_FALLBACK_LIBRARY_PATH  && \ # avoids conda installation error on macOS
+                    Rscript -e 'BiocManager::install("basilisk", type="source")'
 
             # Install conda for basilisk manually
             - name: Check basilisk conda installation
               shell: Rscript {0}
               run: |
                   basilisk.utils::getCondaDir()
-
-            - name: Install R dependencies
-              uses: r-lib/actions/setup-r-dependencies@7171bbdc297d5a76f04914d60e5c8144991e3011 # v2
-              with:
-                  extra-packages: any::rcmdcheck
-                  needs: check
 
             - name: Run R CMD check
               uses: r-lib/actions/check-r-package@7171bbdc297d5a76f04914d60e5c8144991e3011 # v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,10 +50,10 @@ jobs:
                   use-public-rspm: true
 
             - name: Install basilisk
-              shell: Rscript {0}
               run: |
-                  install.packages("BiocManager")
-                  BiocManager::install("basilisk", type="source")
+                  Rscript -e 'install.packages("BiocManager")'
+                  unset DYLD_FALLBACK_LIBRARY_PATH # avoids conda installation error on macOS
+                  Rscript -e 'BiocManager::install("basilisk", type="source")'
 
             # Install conda for basilisk manually
             - name: Check basilisk conda installation

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,9 +43,16 @@ jobs:
                   http-user-agent: ${{ matrix.config.http-user-agent }}
                   use-public-rspm: true
 
-            # Install miniconda manually, to prevent installation errors on GHA runners
-            - name: Setup Miniconda
-              uses: conda-incubator/setup-miniconda@v3.0.3
+            - name: Install basilisk.utils
+              shell: Rscript {0}
+              run: |
+                  install.packages("BiocManager")
+                  BiocManager::install("basilisk.utils")
+
+            # Install conda for basilisk manually
+            - name: Setup basilisk conda
+              shell: Rscript {0}
+              run: basilisk.utils::installConda()
 
             - name: Install R dependencies
               uses: r-lib/actions/setup-r-dependencies@7171bbdc297d5a76f04914d60e5c8144991e3011 # v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 URL: https://github.com/milanmlft/jupytextR, https://milanmlft.github.io/jupytextR/
 BugReports: https://github.com/milanmlft/jupytextR/issues
 StagedInstall: no


### PR DESCRIPTION
After a few attempts to fix the `macOS` GHA checks, decided to disable it for now as the issue is likely in an upstream dependency of `jupytextR`. 

See #28 